### PR TITLE
Improved FC read in

### DIFF
--- a/cinema.py
+++ b/cinema.py
@@ -5,10 +5,24 @@
 # written by: Alexander Riegel, May 2023                                 #
 ##########################################################################
 
+import argparse
 import os
 from contextlib import contextmanager
 import subprocess
 import shutil
+
+
+# set up argument parser
+parser = argparse.ArgumentParser(
+        description='''ELDEST -- cinema.py :
+        An auxiliary programme to create a movie (gif) of P-E_kin spectra for different times
+        from the file movie.dat (produced by, e.g., nuclear_dyn.py .''',
+        epilog='By Alexander V. Riegel.')
+parser.add_argument('-E', '--E_lims', nargs=2, default=[9.8, 10.5], metavar=('E_low', 'E_high'),
+                    help='Lower and upper limit for E_kin (in eV).')
+args = parser.parse_args()
+
+
 
 @contextmanager # https://stackoverflow.com/questions/431684/equivalent-of-shell-cd-command-to-change-the-working-directory/24176022#24176022 (2023-May-22)
 def cd(newdir):
@@ -23,14 +37,18 @@ def cd(newdir):
 gnufile = open('gnufile.gp', 'w')
 gnufile.write("""
         set terminal png size 1600,1200 enhanced
-        set xrange [9.8:10.5]
+        set xrange [ARG2:ARG3]
         set yrange [0:1.1*ARG1]             # set ymax as 110 % of maximum intensity (will be passed as argument)
+        print ARG1
+        print ARG2
+        print ARG3
         set xlabel "E_{kin} / eV"
+        set ylabel "P(E_{kin}) / a.u."
         set key autotitle columnhead
         files = system('ls -1 *.txt')
         do for [file in files]{
         set output file.".png"
-        plot file u 1:3 w l lw 3 lc 3
+        plot file u 1:(column($#)) tit columnhead(1) w l lw 3 lc 3    # $# evaluates to total number of columns in current line
         }
         """)
 gnufile.close()
@@ -39,14 +57,14 @@ gnufile.close()
 os.mkdir('tempplot')
 os.system('cp movie.dat tempplot/.')
 os.system('mv gnufile.gp tempplot/.')
-maxim = float(subprocess.check_output("awk 'BEGIN{a=0}{if ($3>0+a) a=$3} END{print a}' movie.dat", shell=True)[:-1])    # maximum intensity
+maxim = float(subprocess.check_output("awk 'BEGIN{a=0}{if ($NF>0+a && NF>2) a=$NF} END{print a}' movie.dat", shell=True)[:-1])    # maximum intensity; NF>2 skips the "xxx fs" lines
 
 with cd('./tempplot'):    # automatically reverts back to cwd after being finished
-    # 1) split movie.dat along empty lines, enumerate files with three-digit number (FILE001.txt, FILE002.txt etc.)
+    # 1) split movie.dat along empty lines, enumerate files with four-digit number (FILE0001.txt, FILE0002.txt etc.)
     # 2) gnuplot, pass maximum intensity as variable
     # 3) ffmpeg converts png images into gif movie
-    os.system("""   tr -d '\r' < movie.dat | awk '{print > sprintf("%s%03d%s", "FILE", ++CNT, ".txt")}' RS=''   """)
-    os.system("gnuplot -c gnufile.gp %s" % maxim)
-    os.system("ffmpeg -loglevel warning -f image2 -r 10.0 -i FILE%03d.txt.png -q:v 1 -pattern_type globe -codec gif ../movie.gif")
+    os.system("""   tr -d '\r' < movie.dat | awk '{print > sprintf("%s%04d%s", "FILE", ++CNT, ".txt")}' RS=''   """)
+    os.system("gnuplot -c gnufile.gp {} {} {}".format(maxim, *args.E_lims))
+    os.system("ffmpeg -loglevel warning -f image2 -r 10.0 -i FILE%04d.txt.png -q:v 1 -pattern_type globe -codec gif ../movie.gif")
 
 shutil.rmtree("tempplot")

--- a/cinema.py
+++ b/cinema.py
@@ -17,6 +17,7 @@ parser = argparse.ArgumentParser(
         description='''ELDEST -- cinema.py :
         An auxiliary programme to create a movie (gif) of P-E_kin spectra for different times
         from the file movie.dat (produced by, e.g., nuclear_dyn.py .''',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         epilog='By Alexander V. Riegel.')
 parser.add_argument('-E', '--E_lims', nargs=2, default=[9.8, 10.5], metavar=('E_low', 'E_high'),
                     help='Lower and upper limit for E_kin (in eV).')

--- a/cinema.py
+++ b/cinema.py
@@ -16,7 +16,7 @@ import shutil
 parser = argparse.ArgumentParser(
         description='''ELDEST -- cinema.py :
         An auxiliary programme to create a movie (gif) of P-E_kin spectra for different times
-        from the file movie.dat (produced by, e.g., nuclear_dyn.py .''',
+        from the file movie.dat (produced by, e.g., nuclear_dyn.py).''',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         epilog='By Alexander V. Riegel.')
 parser.add_argument('-E', '--E_lims', nargs=2, default=[9.8, 10.5], metavar=('E_low', 'E_high'),

--- a/in_out.py
+++ b/in_out.py
@@ -18,6 +18,9 @@ import sys
 def read_input(inputfile, outfile):
 #-------------------------------------------------------------------------
     # define default parameters
+    # process: ICD or RICD
+    prc          = "RICD"         # options: ICD, RICD
+    #
     # transitions dipole moments
     rdg_au       = 0.3            # transition dipole moment into the resonance state
     cdg_au       = 0.9            # transition dipole moment into any continuum state
@@ -55,9 +58,13 @@ def read_input(inputfile, outfile):
     tmax_s        = 2.5E-15       # simulate until time tmax in s
     timestep_s    = 0.5E-16       # evaluate expression every timestep_s seconds
     E_step_eV     = 1.00          # energy difference between different evaluated electron kinetic energies 
+    Ep_step_eV    = 1.00          # energy difference between different evaluated photoelectron kinetic energies 
     #
     E_min_eV      =  30.0
     E_max_eV      =  50.0
+    #
+    Ep_min_eV     =  10.0
+    Ep_max_eV     =  11.0
     #
     integ         = "analytic"    # options: analytic, (quadrature, romberg - both currently unavailable)  
     integ_outer   = "romberg"     # options: quadrature, romberg
@@ -98,7 +105,23 @@ def read_input(inputfile, outfile):
     
     for line in lines:
         words = line.split()
-        if (words[0] == 'rdg_au'):
+        if (words[0] == 'prc'):
+            if (words[2] == 'ICD'):
+                X_ICD = True
+                X_RICD = False
+                print('X_prc = ICD')
+                outfile.write('X_prc = ICD \n')
+            elif (words[2] == 'RICD'):
+                X_ICD = False
+                X_RICD = True
+                print('X_prc = RICD')
+                outfile.write('X_prc = RICD \n')
+            else:
+                print('no process selected')
+                outfile.write('no process selected \n')
+                
+    # prefactors            
+        elif (words[0] == 'rdg_au'):
             rdg_au = float(words[2])
             print('rdg_au = ', rdg_au)
             outfile.write('rdg_au = ' + str(rdg_au) + '\n')
@@ -238,6 +261,10 @@ def read_input(inputfile, outfile):
             E_step_eV = float(words[2])
             print('E_step_eV = ', E_step_eV)
             outfile.write('E_step_eV = ' + str(E_step_eV) + '\n')
+        elif (words[0] == 'Ep_step_eV'):
+            Ep_step_eV = float(words[2])
+            print('E_step_eV = ', E_step_eV)
+            outfile.write('E_step_eV = ' + str(E_step_eV) + '\n')
     
         elif (words[0] == 'E_min_eV'):
             E_min_eV = float(words[2])
@@ -247,6 +274,15 @@ def read_input(inputfile, outfile):
             E_max_eV = float(words[2])
             print('E_max_eV = ', E_max_eV)
             outfile.write('E_max_eV = ' + str(E_max_eV) + '\n')
+            
+        elif (words[0] == 'Ep_min_eV'):
+            Ep_min_eV = float(words[2])
+            print('Ep_min_eV = ', Ep_min_eV)
+            outfile.write('Ep_min_eV = ' + str(Ep_min_eV) + '\n')
+        elif (words[0] == 'Ep_max_eV'):
+            Ep_max_eV = float(words[2])
+            print('Ep_max_eV = ', Ep_max_eV)
+            outfile.write('Ep_max_eV = ' + str(Ep_max_eV) + '\n')
 
         elif (words[0] == 'integ'):
             if (words[2] == 'romberg'):
@@ -362,13 +398,15 @@ def read_input(inputfile, outfile):
                 sys.exit()
     
     f.close()
-    return (rdg_au, cdg_au,
+    return (X_ICD, X_RICD,
+            rdg_au, cdg_au,
             Er_a_eV, Er_b_eV, tau_a_s, tau_b_s, E_fin_eV, tau_s, E_fin_eV_2, tau_s_2,
             interact_eV,
             Omega_eV, n_X, I_X, X_sinsq, X_gauss, Xshape,
             omega_eV, n_L, I_L, Lshape, delta_t_s, shift_step_s, phi, q, FWHM_L,
-            tmax_s, timestep_s, E_step_eV,
+            tmax_s, timestep_s, E_step_eV, Ep_step_eV,
             E_min_eV, E_max_eV,
+            Ep_min_eV, Ep_max_eV,
             integ, integ_outer, Gamma_type,
             fc_precalc, partial_GamR, part_fc_pre, wavepac_only,
             mass1, mass2, grad_delta, R_eq_AA,
@@ -750,14 +788,13 @@ def read_fc_input(inputfile):
 
 #-------------------------------------------------------------------------
 #   output
-#   output
-def prep_output(I, Omega_au, t_au):
+def prep_output(I, Omega_au, t_au, Ep):
 #    square = np.absolute(I)**2
     #print I
+    Ep_eV = sciconv.hartree_to_ev(Ep)
     Omega_eV = sciconv.hartree_to_ev(Omega_au)
     t_s = sciconv.atu_to_second(t_au)
-    string = format(Omega_eV, '>8.5f') + '   ' + format(t_s, ' .18f') + '   ' + format(I, '.15e')
-    #string = str(Omega_eV) + '   ' + format(t_s, '.18f') + '   ' + format(I, '.15e')
+    string = format(Omega_eV, '>8.5f') + '   ' + format(Ep_eV, '>8.5f') + '   ' + format(t_s, ' .18f') + '   ' + format(I, '.15e')
     return string
 
 def prep_output_comp(I, I2, Omega_au, t_au):

--- a/in_out.py
+++ b/in_out.py
@@ -263,8 +263,8 @@ def read_input(inputfile, outfile):
             outfile.write('E_step_eV = ' + str(E_step_eV) + '\n')
         elif (words[0] == 'Ep_step_eV'):
             Ep_step_eV = float(words[2])
-            print('E_step_eV = ', E_step_eV)
-            outfile.write('E_step_eV = ' + str(E_step_eV) + '\n')
+            print('Ep_step_eV = ', Ep_step_eV)
+            outfile.write('Ep_step_eV = ' + str(Ep_step_eV) + '\n')
     
         elif (words[0] == 'E_min_eV'):
             E_min_eV = float(words[2])

--- a/nuclear_dyn.py
+++ b/nuclear_dyn.py
@@ -67,8 +67,10 @@ parser.add_argument('-g', '--gamma', help='''Optional binary file containing the
 #                    only into the overlap integrals in the prefactors for the transition amplitude
 #                    but not in W_lambda in the exponents. If 'exponent' or 'exp' or 'Wl' is chosen, the reverse is true.
 #                    If none is given, the Gamma(R) dependence is incorporated in all relevant places (default).''')
-parser.add_argument('-F', '--FC', help='''Same as '-f' and '--fc', but for an additional set with overlap integrals
-                    without Gamma(R) dependence in the res-fin integrals. The file structure is the same as before.
+parser.add_argument('-F', '--FC', help='''Same as '-f' and '--fc', but for an additional file with overlap integrals
+                    without Gamma(R) dependence in the res-fin integrals. The file structure is the same as before;
+                    this also means that only one res-fin block will be recognized - if the file contains both
+                    res-fin integrals with and without Gamma(R) dependence, the block with Gamma(R) must be deleted.
                     +++ This option is only available if partial_GamR is not None.''')
 #                    +++ This option is only available in combination with the -p/--partial option.''')
 #parser.add_argument('-w', '--wavepacket_only', action='store_true', help='''If this flag is given, only the projection

--- a/nuclear_dyn.py
+++ b/nuclear_dyn.py
@@ -700,10 +700,10 @@ if partial_GamR:
                     print(('{:5d}  {:5d}  {: 14.10E}'.format(l,m,FC)))
                     print('   ...')
     print('These additional overlaps without the V(R) dependence are used\n only in',
-            'the prefactors to the time integrals' if (partial_GamR == 'pre') else 'the calculation of the W_lambda values')
+            'the prefactors to the time integrals' if (partial_GamR == 'exp') else 'the calculation of the W_lambda values')
     outfile.write('These additional overlaps without the V(R) dependence are used\n only in '
-            + ('the prefactors to the time integrals' if (partial_GamR == 'pre') else 'the calculation of the W_lambda values')
-            + '\n')
+            + ('the prefactors to the time integrals' if (partial_GamR == 'exp') else 'the calculation of the W_lambda values')
+            + '\n')     # If 'exp', then W_lambda is calced with Gamma(R) but they prefactors are not
 
 # sum over mup of product <lambda|mup><mup|kappa>       where mup means mu prime
 indir_FCsums = []

--- a/nuclear_dyn.py
+++ b/nuclear_dyn.py
@@ -438,40 +438,44 @@ if partial_GamR:
         res_fin_woVR.append(list())
 
 
-# Numerical integration failsafe check: calculate test FC overlap integral
-print()
-print('-----------------------------------------------------------------')
-outfile.write('\n' + '-----------------------------------------------------------------' + '\n')
-#print('Numerical integration test')
-#
-#if fin_pot_type == 'morse':
-#    func = lambda R: (np.conj(wf.psi_n(R,0,res_a,res_Req,red_mass,res_de))
-#                      * wf.psi_n(R,0,fin_a,fin_Req,red_mass,fin_de)
-#                      * V_of_R(R))
-#elif fin_pot_type == 'hypfree':
-#    func = lambda R: (np.conj(wf.psi_n(R,0,res_a,res_Req,red_mass,res_de))
-#                      * wf.psi_freehyp(R,fin_hyp_a,fin_hyp_b,red_mass,R_start_EX_max)
-#                      * V_of_R(R))
-#elif fin_pot_type == 'hyperbel':
-#    func = lambda R: (np.conj(wf.psi_n(R,0,res_a,res_Req,red_mass,res_de))
-#                      * wf.psi_hyp(R,fin_hyp_a,fin_hyp_b,red_mass,R_start_EX_max)
-#                      * V_of_R(R))
-#tmp = np.zeros(2)
-#while abs(tmp[0]) <= (1000*tmp[1]):                 # checks if the test integral is at least three orders of magnitude larger than the estimated error
-#    R_min -= 0.01                                   # if so: lower the lower integration bound by 0.01 bohr
-#    tmp = integrate.quad(func, R_min, R_max,epsabs=1e-20,limit=500)
-#    #print(R_min, tmp)  #?
-R_min -= 0.01       # Counteract the +0.01 bohr when R_min was defined
 
-print('Lower bound of integration over R for the Franck-Condon factors')
-print('R_min = {:14.10E} au = {:5.5f} A'.format(R_min, sciconv.bohr_to_angstrom(R_min)))
-print('Hope that is in order.')
-outfile.write('Lower bound of integration over R for the Franck-Condon factors' + '\n')
-outfile.write('R_min = {:14.10E} au = {:5.5f} A\n'.format(R_min, sciconv.bohr_to_angstrom(R_min)))
-outfile.write('Hope that is in order.' + '\n')
-
-# calc ground state - resonance state <lambda|kappa>
+# Integration bounds;       and calc ground state - resonance state <lambda|kappa>
 if not args.fc:                 # If, however, an FC input file is provided, FC integrals will be read from it in the next step and their calculation skipped
+    # Numerical integration failsafe check: calculate test FC overlap integral
+    print()
+    print('-----------------------------------------------------------------')
+    outfile.write('\n' + '-----------------------------------------------------------------' + '\n')
+    # print('Numerical integration test')
+    #
+    # if fin_pot_type == 'morse':
+    #    func = lambda R: (np.conj(wf.psi_n(R,0,res_a,res_Req,red_mass,res_de))
+    #                      * wf.psi_n(R,0,fin_a,fin_Req,red_mass,fin_de)
+    #                      * V_of_R(R))
+    # elif fin_pot_type == 'hypfree':
+    #    func = lambda R: (np.conj(wf.psi_n(R,0,res_a,res_Req,red_mass,res_de))
+    #                      * wf.psi_freehyp(R,fin_hyp_a,fin_hyp_b,red_mass,R_start_EX_max)
+    #                      * V_of_R(R))
+    # elif fin_pot_type == 'hyperbel':
+    #    func = lambda R: (np.conj(wf.psi_n(R,0,res_a,res_Req,red_mass,res_de))
+    #                      * wf.psi_hyp(R,fin_hyp_a,fin_hyp_b,red_mass,R_start_EX_max)
+    #                      * V_of_R(R))
+    # tmp = np.zeros(2)
+    # while abs(tmp[0]) <= (1000*tmp[1]):                 # checks if the test integral is at least three orders of magnitude larger than the estimated error
+    #    R_min -= 0.01                                   # if so: lower the lower integration bound by 0.01 bohr
+    #    tmp = integrate.quad(func, R_min, R_max,epsabs=1e-20,limit=500)
+    #    #print(R_min, tmp)  #?
+    R_min -= 0.01  # Counteract the +0.01 bohr when R_min was defined
+
+    print('Bounds of integration over R for the Franck-Condon factors')
+    print('R_min = {:14.10E} au = {:5.5f} A'.format(R_min, sciconv.bohr_to_angstrom(R_min)))
+    print('R_max = {:14.10E} au = {:5.5f} A'.format(R_max, sciconv.bohr_to_angstrom(R_max)))
+    print('Hope that is in order.')
+    outfile.write('Bounds of integration over R for the Franck-Condon factors' + '\n')
+    outfile.write('R_min = {:14.10E} au = {:5.5f} A\n'.format(R_min, sciconv.bohr_to_angstrom(R_min)))
+    outfile.write('R_max = {:14.10E} au = {:5.5f} A\n'.format(R_max, sciconv.bohr_to_angstrom(R_max)))
+    outfile.write('Hope that is in order.' + '\n')
+
+    # calc ground state - resonance state <lambda|kappa>
     for k in range (0,n_gs_max+1):
         tmp = []
         for l in range (0,n_res_max+1):

--- a/nuclear_dyn.py
+++ b/nuclear_dyn.py
@@ -131,6 +131,12 @@ movie_out = open('movie.dat' if not wavepac_only else devnull, mode='w')
 #popfile = open("pop.dat", mode='w')
 wp_res_out = open('wp_res.dat', mode='w')
 
+def close_files():
+    outfile.close
+    pure_out.close
+    movie_out.close
+    wp_res_out.close
+
 if fc_precalc:
     print('The Franck-Condon overlap integrals are read from file: ' + str(args.fc))
     outfile.write('The Franck-Condon overlap integrals are read from file: ' + str(args.fc) + '\n')
@@ -367,58 +373,31 @@ for l in range(0,n_res_max+1):
     res_fin.append(list())
 
 if not fc_precalc and args.fc:
-    outfile.close
-    pure_out.close
-    movie_out.close
-    wp_res_out.close
+    close_files()
     sys.exit('!!! FC input file was provided without being requested. Programme terminated.')
 elif fc_precalc and not args.fc:
-    outfile.close
-    pure_out.close
-    movie_out.close
-    wp_res_out.close
+    close_files()
     sys.exit('!!! FC input file was requested but not provided. Programme terminated.')
 elif not (Gamma_type == 'external') and args.gamma:
-    outfile.close
-    pure_out.close
-    movie_out.close
-    wp_res_out.close
+    close_files()
     sys.exit('!!! Gamma-R-dependence file was provided although Gamma_type is not "external". Programme terminated.')
 elif (Gamma_type == 'external') and not args.fc and not args.gamma:
-    outfile.close
-    pure_out.close
-    movie_out.close
-    wp_res_out.close
+    close_files()
     sys.exit('!!! Gamma_type is "external" but no additional input file was provided. Programme terminated.')
 elif args.fc and args.gamma:
-    outfile.close
-    pure_out.close
-    movie_out.close
-    wp_res_out.close
+    close_files()
     sys.exit('!!! FC input file and Gamma-R-dependence file were provided at the same time. Programme terminated.')
 elif not part_fc_pre and args.FC:
-    outfile.close
-    pure_out.close
-    movie_out.close
-    wp_res_out.close
+    close_files()
     sys.exit('!!! FC input file for partial Gamma-R dependence was provided without being requested. Programme terminated.')
 elif part_fc_pre and not args.FC:
-    outfile.close
-    pure_out.close
-    movie_out.close
-    wp_res_out.close
+    close_files()
     sys.exit('!!! FC input file for partial Gamma-R dependence was requested but not provided. Programme terminated.')
 elif part_fc_pre and not partial_GamR:
-    outfile.close
-    pure_out.close
-    movie_out.close
-    wp_res_out.close
+    close_files()
     sys.exit('!!! FC input file for partial Gamma-R dependence was requested although no such treatment was requested. Programme terminated.')
 elif partial_GamR and ((args.fc and not args.FC) or (args.FC and not args.fc)):   # If partial_GamR but -f and -F not either both present or both absent, throw error (FC calc code would have to be changed)  
-    outfile.close
-    pure_out.close
-    movie_out.close
-    wp_res_out.close
+    close_files()
     sys.exit('!!! If partial_GamR is requested, then either both or none of the additional FC input files with (-f) and without (-F) Gamma-R dependence must be provided at the moment. Programme terminated.')
 
 
@@ -494,10 +473,7 @@ if (fin_pot_type == 'morse'):
             gs_res_woVR, gs_fin_woVR, res_fin_woVR, _, _ = in_out.read_fc_input(args.FC)
             if not (gs_res_woVR == gs_res and gs_fin_woVR == gs_fin and len(res_fin) == len(res_fin_woVR)):
                 outfile.write("gs_res: " + str(gs_res_woVR == gs_res) + ", gs_fin: " + str(gs_fin_woVR == gs_fin) + ", len(res_fin): " + str(len(res_fin) == len(res_fin_woVR)) + "\n")
-                outfile.close
-                pure_out.close
-                movie_out.close
-                wp_res_out.close
+                close_files()
                 sys.exit('!!! Files of FC integrals with and without Gamma(R) dependence are incompatible. Programme terminated.')
     else:
         for m in range(0,n_fin_max+1):
@@ -532,10 +508,7 @@ elif (fin_pot_type in ('hyperbel','hypfree')):
                     and n_fin_max_X_woVR == n_fin_max_X and len(res_fin) == len(res_fin_woVR)):
                 outfile.write("gs_res: " + str(gs_res_woVR == gs_res) + ", gs_fin: " + str(gs_fin_woVR == gs_fin) + ", max_list: " + str(n_fin_max_list_woVR == n_fin_max_list)
                               + ", max_X: " + str(n_fin_max_X_woVR == n_fin_max_X) + ", len(res_fin): " + str(len(res_fin) == len(res_fin_woVR)) + "\n")
-                outfile.close
-                pure_out.close
-                movie_out.close
-                wp_res_out.close
+                close_files()
                 sys.exit('!!! Files of FC integrals with and without Gamma(R) dependence are incompatible. Programme terminated.')
 
     else:
@@ -1176,7 +1149,4 @@ print(str(dt_end))
 outfile.write('\n' + str(dt_end) + '\n')
 outfile.write('Total runtime:' + ' ' + str(dt_end - dt_start))
 
-outfile.close
-pure_out.close
-movie_out.close
-wp_res_out.close
+close_files()

--- a/nuclear_dyn.py
+++ b/nuclear_dyn.py
@@ -11,7 +11,7 @@
 ##########################################################################
 # written by: Elke Fasshauer November 2020                               #
 # extended by: Alexander Riegel from July 2023 onwards                   #
-# last change: 2025-06-25 AVR                                            #
+# last change: 2026-06-02 AVR                                            #
 ##########################################################################
 
 import argparse
@@ -108,13 +108,15 @@ Xshape = 'convoluted'
 
 # (q is explicit input, not calced as q = rdg / (cdg pi VEr) = sqrt(2 tau / pi) rdg / cdg )
 
-(rdg_au, cdg_au,
+(X_ICD, X_RICD,
+ rdg_au, cdg_au,
  Er_a_eV, Er_b_eV, tau_a_s, tau_b_s, E_fin_eV, tau_s, E_fin_eV_2, tau_s_2,
  interact_eV,
  Omega_eV, n_X, I_X, X_sinsq, X_gauss, Xshape,
  omega_eV, n_L, I_L, Lshape, delta_t_s, shift_step_s, phi, q, FWHM_L,
- tmax_s, timestep_s, E_step_eV,
+ tmax_s, timestep_s, E_step_eV, Ep_step_eV,
  E_min_eV, E_max_eV,
+ Ep_min_eV, Ep_max_eV,
  integ, integ_outer, Gamma_type,
  fc_precalc, partial_GamR, part_fc_pre, wavepac_only,
  mass1, mass2, grad_delta, R_eq_AA,
@@ -182,6 +184,13 @@ if Gamma_type == 'const':
 #tau_au_2         = sciconv.second_to_atu(tau_s_2)
 #Gamma_au_2       = 1. / tau_au_2
 
+# nucl-nucl Coulomb repulsion for ICD
+if (X_ICD):
+    R_eq_au = sciconv.angstrom_to_bohr(R_eq_AA)
+    E_fin_au = E_fin_au + 1 / R_eq_au
+    print('E_fin_au = E_fin_au + 1 / R =', E_fin_au)
+    outfile.write('E_fin_au = E_fin_au + 1 / R = ' + str(E_fin_au)  + '\n')
+
 # laser parameters
 Omega_au      = sciconv.ev_to_hartree(Omega_eV)
 if (X_sinsq):
@@ -234,9 +243,20 @@ delta_t_au    = sciconv.second_to_atu(delta_t_s)        # t diff between the max
 tmax_au       = sciconv.second_to_atu(tmax_s)
 timestep_au   = sciconv.second_to_atu(timestep_s)
 E_step_au = sciconv.ev_to_hartree(E_step_eV)
+Ep_step_au = sciconv.ev_to_hartree(Ep_step_eV)
 
 E_min_au = sciconv.ev_to_hartree(E_min_eV)
 E_max_au = sciconv.ev_to_hartree(E_max_eV)
+
+if (X_ICD and not X_RICD):
+    Ep_min_au = sciconv.ev_to_hartree(Ep_min_eV)
+    Ep_max_au = sciconv.ev_to_hartree(Ep_max_eV)
+elif (X_RICD and not X_ICD):
+    Ep_min_au = 0
+    Ep_max_au = 0
+else:   # This should not happen thanks to default settings
+    close_files()
+    sys.exit('!!! Process was not specified correctly. Programme terminated.')
 
 VEr_au        = np.sqrt(Gamma_au/ (2*np.pi))
 #VEr_au_1      = VEr_au      # (same as for Er)
@@ -798,11 +818,11 @@ elif (integ == 'analytic'):
                               - np.exp(t1 * (1j*(E_kin_au + E_fin_au
                                                  - Er_au - E_lambda)
                                                   - np.pi * W_au)))
-                            * np.exp(-1j*t_au * (E_kin_au + E_fin_au))
+                            * np.exp(-1j*t_au * (E_kin_au + E_fin_au + E_p_au))
                            )
 
 res_outer_fun = lambda t1: FX_t1(t1) \
-                           * np.exp(t1 * (np.pi* W_au + 1j*(Er_au + E_lambda))) \
+                           * np.exp(t1 * (np.pi* W_au + 1j*(Er_au + E_lambda + E_p_au))) \
                            * res_inner(t1)
 
 
@@ -837,13 +857,19 @@ def wp_res_int(t,T_up):
 t_au = -TX_au/2
 
 
-# construct list of energy points
+# construct list of energy points for E_kin (secondary electron)
 Ekins = []
 E_kin_au = E_min_au
 while (E_kin_au <= E_max_au):
     Ekins.append(sciconv.hartree_to_ev(E_kin_au))
     E_kin_au = E_kin_au + E_step_au
 
+# construct list of energy points for E_p (photoelectron)
+Ep = []
+E_p_au = Ep_min_au
+while (E_p_au <= Ep_max_au):
+    Ep.append(sciconv.hartree_to_ev(E_p_au))
+    E_p_au = E_p_au + Ep_step_au
 
 #-------------------------------------------------------------------------
 # constants / prefactors
@@ -875,7 +901,7 @@ while ((t_au <= TX_au/2) and (t_au <= tmax_au)):
     outfile.write('during the first pulse \n')
     print('during the first pulse')
 
-    outlines = []       # will contain lines containing triples of E_kin, time and signal intensity
+    outlines = []       # will contain lines containing E_kin, E_p, time and signal intensity
     squares = np.array([])  # signal intensity ( = |amplitude|**2 = |J|**2 )
     E_kin_au = E_min_au
     
@@ -892,98 +918,102 @@ while ((t_au <= TX_au/2) and (t_au <= tmax_au)):
             else:
                 print('-', end = '', flush = True)
                 cnt = cnt + 1
-            #print(f'{sciconv.hartree_to_ev(E_kin_au):.2} eV')           #?
-            #outfile.write(f'{sciconv.hartree_to_ev(E_kin_au):.2} eV\n') #?
-            p_au = np.sqrt(2*E_kin_au)
-            sum_square = 0      # Total spectrum |J @ E_kin|**2 = sum_mu |J_mu @ E_kin|**2  (sum of contributions of all final states with E_kin); for continuous mu: int ~ sum
-            if t_au==-TX_au/2:
-                squares = np.append(squares, 0.)
-                string = in_out.prep_output(0., E_kin_au, t_au)
-                outlines.append(string)
-                E_kin_au = E_kin_au + E_step_au
-                continue
+            E_p_au = Ep_min_au
+            while (E_p_au <= Ep_max_au):
+                #print(f'{sciconv.hartree_to_ev(E_kin_au):.2} eV')           #?
+                #outfile.write(f'{sciconv.hartree_to_ev(E_kin_au):.2} eV\n') #?
+                p_au = np.sqrt(2*E_kin_au)
+                sum_square = 0      # Total spectrum |J @ E_kin|**2 = sum_mu |J_mu @ E_kin|**2  (sum of contributions of all final states with E_kin); for continuous mu: int ~ sum
+                if t_au==-TX_au/2:
+                    squares = np.append(squares, 0.)
+                    string = in_out.prep_output(0., E_kin_au, t_au, E_p_au)
+                    outlines.append(string)
+                    E_p_au = E_p_au + Ep_step_au
+                    continue
     
-            for nmu in range (0, n_fin_max + 1):           # loop over all mu, calculate J_mu = J_dir,mu + J_nondir,mu
-                E_fin_au = E_fin_au_1 + E_mus[nmu]      # E_fin_au_1: inputted electronic E_fin_au, E_mus: vibrational eigenvalues of fin state
-        #            Er_au = Er_a_au
-                
-                # Direct term
-                if (integ_outer == "quadrature"):
-                    I1 = ci.complex_quadrature(fun_t_dir_1, (-TX_au/2), t_au)
-                    dir_J1 = prefac_dir1 * I1[0] * gs_fin[0][nmu]        # [0] of quad integ result = integral (rest is est error & info); FC = <mu_n|kappa_0>
-    
-                elif (integ_outer == "romberg"):
-                    I1 = ci.complex_romberg(fun_t_dir_1, (-TX_au/2), t_au)
-                    dir_J1 = prefac_dir1 * I1 * gs_fin[0][nmu]           # romberg returns only the integral, so no [0] necessary
-                 
-                # J_nondir,mu = sum_lambda J_nondir,mu,lambda = sum_lambda (J_res,mu,lambda + J_indir,mu,lambda)
-                J = 0
-                for nlambda in range (0,n_res_max+1):
-                    if (fin_pot_type in ('hyperbel','hypfree') and nmu > n_fin_max_list[nlambda]):  # J_nondir,mu,lambda = 0 if repulsive |fin>|mu> lies higher than |res>|lambda>
-                        continue
-                    E_lambda = E_lambdas[nlambda]
-                    W_au = W_lambda[nlambda]
+                for nmu in range (0, n_fin_max + 1):           # loop over all mu, calculate J_mu = J_dir,mu + J_nondir,mu
+                    E_fin_au = E_fin_au_1 + E_mus[nmu]      # E_fin_au_1: inputted electronic E_fin_au, E_mus: vibrational eigenvalues of fin state
+        #                Er_au = Er_a_au
+                    
+                    # Direct term
                     if (integ_outer == "quadrature"):
-                        res_I = ci.complex_quadrature(res_outer_fun, (-TX_au/2), t_au)
-        
-                        if not partial_GamR == 'exp':
-                            res_J1 = (prefac_res1 * res_I[0]
-                                      * gs_res[0][nlambda] * res_fin[nlambda][nmu])
-                            indir_J1 = (prefac_indir1 * res_I[0]
-                                        * indir_FCsums[nlambda] * res_fin[nlambda][nmu])
-                        else:
-                            res_J1 = (prefac_res1 * res_I[0]
-                                      * gs_res[0][nlambda] * res_fin_woVR[nlambda][nmu])
-                            indir_J1 = (prefac_indir1 * res_I[0]
-                                        * indir_FCsums[nlambda] * res_fin_woVR[nlambda][nmu])
+                        I1 = ci.complex_quadrature(fun_t_dir_1, (-TX_au/2), t_au)
+                        dir_J1 = prefac_dir1 * I1[0] * gs_fin[0][nmu]        # [0] of quad integ result = integral (rest is est error & info); FC = <mu_n|kappa_0>
     
                     elif (integ_outer == "romberg"):
-                        res_I = ci.complex_romberg(res_outer_fun, (-TX_au/2), t_au)
-                    
-                        if not partial_GamR == 'exp':
-                            res_J1 = (prefac_res1 * res_I
-                                      * gs_res[0][nlambda] * res_fin[nlambda][nmu])
-                            indir_J1 = (prefac_indir1 * res_I
-                                        * indir_FCsums[nlambda] * res_fin[nlambda][nmu])
-                        else:
-                            res_J1 = (prefac_res1 * res_I
-                                      * gs_res[0][nlambda] * res_fin_woVR[nlambda][nmu])
-                            indir_J1 = (prefac_indir1 * res_I
-                                        * indir_FCsums[nlambda] * res_fin_woVR[nlambda][nmu])
+                        I1 = ci.complex_romberg(fun_t_dir_1, (-TX_au/2), t_au)
+                        dir_J1 = prefac_dir1 * I1 * gs_fin[0][nmu]           # romberg returns only the integral, so no [0] necessary
+                     
+                    # J_nondir,mu = sum_lambda J_nondir,mu,lambda = sum_lambda (J_res,mu,lambda + J_indir,mu,lambda)
+                    J = 0
+                    for nlambda in range (0,n_res_max+1):
+                        if (fin_pot_type in ('hyperbel','hypfree') and nmu > n_fin_max_list[nlambda]):  # J_nondir,mu,lambda = 0 if repulsive |fin>|mu> lies higher than |res>|lambda>
+                            continue
+                        E_lambda = E_lambdas[nlambda]
+                        W_au = W_lambda[nlambda]
+                        if (integ_outer == "quadrature"):
+                            res_I = ci.complex_quadrature(res_outer_fun, (-TX_au/2), t_au)
         
-                    J = (J
-                         + res_J1
-                         + indir_J1
-                         )
+                            if not partial_GamR == 'exp':
+                                res_J1 = (prefac_res1 * res_I[0]
+                                          * gs_res[0][nlambda] * res_fin[nlambda][nmu])
+                                indir_J1 = (prefac_indir1 * res_I[0]
+                                            * indir_FCsums[nlambda] * res_fin[nlambda][nmu])
+                            else:
+                                res_J1 = (prefac_res1 * res_I[0]
+                                          * gs_res[0][nlambda] * res_fin_woVR[nlambda][nmu])
+                                indir_J1 = (prefac_indir1 * res_I[0]
+                                            * indir_FCsums[nlambda] * res_fin_woVR[nlambda][nmu])
+    
+                        elif (integ_outer == "romberg"):
+                            res_I = ci.complex_romberg(res_outer_fun, (-TX_au/2), t_au)
+                        
+                            if not partial_GamR == 'exp':
+                                res_J1 = (prefac_res1 * res_I
+                                          * gs_res[0][nlambda] * res_fin[nlambda][nmu])
+                                indir_J1 = (prefac_indir1 * res_I
+                                            * indir_FCsums[nlambda] * res_fin[nlambda][nmu])
+                            else:
+                                res_J1 = (prefac_res1 * res_I
+                                          * gs_res[0][nlambda] * res_fin_woVR[nlambda][nmu])
+                                indir_J1 = (prefac_indir1 * res_I
+                                            * indir_FCsums[nlambda] * res_fin_woVR[nlambda][nmu])
         
-                # Total trs prob (@E_kin, t) = sum_mu |J_mu|**2
-                # For cont rep fin: int (dE_mu |J_mu|**2 E-DOS(E_mu)) = int (dR_mu |J_mu|**2 R-DOS(R_mu))
-                #   R-DOS = E-DOS * Va / R_mu**2 = E-DOS * E_mu**2 / Va. If E-DOS = 1 & R_hyp_step = const: int (dR_mu |J_mu|**2 R-DOS) ~ sum_mu (R_hyp_step |J_mu|**2 E_mu**2 / Va)
-                square = np.absolute(J + dir_J1)**2     # |J_mu|**2
-                if (fin_pot_type in ('hyperbel','hypfree')):
-                    factor = R_hyp_step * E_mus[nmu]**2 / fin_hyp_a
-                    old_square = square
-                    square = square * factor
-                sum_square = sum_square + square        # |J|**2 = sum_mu |J_mu|**2
-                #print(f'nmu = {nmu:>3}  f = {factor:.5f}  osq = {old_square:.5E}  sq = {square:.5E}  sum = {sum_square:.5E}')
-                #outfile.write(f'nmu = {nmu:>3}  f = {factor:.5f}  osq = {old_square:.5E}  sq = {square:.5E}  sum = {sum_square:.5E}\n')
+                        J = (J
+                             + res_J1
+                             + indir_J1
+                             )
+        
+                    # Total trs prob (@E_kin, t) = sum_mu |J_mu|**2
+                    # For cont rep fin: int (dE_mu |J_mu|**2 E-DOS(E_mu)) = int (dR_mu |J_mu|**2 R-DOS(R_mu))
+                    #   R-DOS = E-DOS * Va / R_mu**2 = E-DOS * E_mu**2 / Va. If E-DOS = 1 & R_hyp_step = const: int (dR_mu |J_mu|**2 R-DOS) ~ sum_mu (R_hyp_step |J_mu|**2 E_mu**2 / Va)
+                    square = np.absolute(J + dir_J1)**2     # |J_mu|**2
+                    if (fin_pot_type in ('hyperbel','hypfree')):
+                        factor = R_hyp_step * E_mus[nmu]**2 / fin_hyp_a
+                        old_square = square
+                        square = square * factor
+                    sum_square = sum_square + square        # |J|**2 = sum_mu |J_mu|**2
+                    #print(f'nmu = {nmu:>3}  f = {factor:.5f}  osq = {old_square:.5E}  sq = {square:.5E}  sum = {sum_square:.5E}')
+                    #outfile.write(f'nmu = {nmu:>3}  f = {factor:.5f}  osq = {old_square:.5E}  sq = {square:.5E}  sum = {sum_square:.5E}\n')
     
-            squares = np.append(squares, sum_square)
+                squares = np.append(squares, sum_square)
     
-            string = in_out.prep_output(sum_square, E_kin_au, t_au)     # returns str: E_kin_eV, t_s, sum_square = intensity
-            outlines.append(string)
+                string = in_out.prep_output(sum_square, E_kin_au, t_au, E_p_au)     # returns str: E_kin_eV, E_p_eV, t_s, sum_square = intensity
+                outlines.append(string)
+
+                E_p_au = E_p_au + Ep_step_au
             
             E_kin_au = E_kin_au + E_step_au     # @ t = const.
         
         
-        in_out.doout_1f(pure_out, outlines)     # writes each (E_kin, t = const, |J|**2) triple in a sep line into output file
+        in_out.doout_1f(pure_out, outlines)     # writes each (E_kin, E_p, t = const, |J|**2) quadruple in a sep line into output file
         in_out.doout_movie(movie_out, outlines)
         print()
         max_pos = argrelextrema(squares, np.greater)[0]      # finds position of relative (i. e. local) maxima of |J|**2 in an array
         if (len(max_pos > 0)):                               # if there are such:
             for i in range (0, len(max_pos)):
-                print(Ekins[max_pos[i]], squares[max_pos[i]])      # print all loc max & resp E_kin
-                outfile.write(str(Ekins[max_pos[i]]) + '  ' + str(squares[max_pos[i]]) + '\n')
+                print(Ekins[max_pos[i] // len(Ep)], Ep[max_pos[i] % len(Ep)], squares[max_pos[i]])      # print all loc max & resp E_kin, E_p
+                outfile.write(str(Ekins[max_pos[i] // len(Ep)]) + '  ' + str(Ep[max_pos[i] % len(Ep)]) + '  ' + str(squares[max_pos[i]]) + '\n')
     
     # wavepacket in resonance state(s)
     wp_ampls = []
@@ -1013,7 +1043,7 @@ while (t_au >= TX_au/2\
 
     # all equal to during-1st-pulse section, except for integrating over entire XUV pulse now
 
-    outlines = []       # will contain lines containing triples of E_kin, time and signal intensity
+    outlines = []       # will contain lines containing E_kin, E_p, time and signal intensity
     squares = np.array([])  # signal intensity ( = |amplitude|**2 = |J|**2 )
     E_kin_au = E_min_au
     
@@ -1030,85 +1060,89 @@ while (t_au >= TX_au/2\
             else:
                 print('-', end = '', flush = True)
                 cnt = cnt + 1
-            #print(f'{sciconv.hartree_to_ev(E_kin_au):.2} eV')           #?
-            #outfile.write(f'{sciconv.hartree_to_ev(E_kin_au):.2} eV\n') #?
-            p_au = np.sqrt(2*E_kin_au)
-            sum_square = 0      # Total spectrum |J @ E_kin|**2 = sum_mu |J_mu @ E_kin|**2  (sum of contributions of all final states with E_kin)
+        E_p_au = Ep_min_au
+        while (E_p_au <= Ep_max_au):
+                #print(f'{sciconv.hartree_to_ev(E_kin_au):.2} eV')           #?
+                #outfile.write(f'{sciconv.hartree_to_ev(E_kin_au):.2} eV\n') #?
+                p_au = np.sqrt(2*E_kin_au)
+                sum_square = 0      # Total spectrum |J @ E_kin|**2 = sum_mu |J_mu @ E_kin|**2  (sum of contributions of all final states with E_kin)
     
-            for nmu in range (0, n_fin_max + 1):           # loop over all mu, calculate J_mu = J_dir,mu + J_nondir,mu
-                E_fin_au = E_fin_au_1 + E_mus[nmu]      # E_fin_au_1: inputted electronic E_fin_au, E_mus: vibrational eigenvalues of fin state
-        #            Er_au = Er_a_au
-                
-                # Direct term
-                if (integ_outer == "quadrature"):
-                    I1 = ci.complex_quadrature(fun_t_dir_1, (-TX_au/2), TX_au/2)
-                    dir_J1 = prefac_dir1 * I1[0] * gs_fin[0][nmu]        # [0] of quad integ result = integral (rest is est error & info); FC = <mu_n|kappa_0>
-    #                    print(nmu, gs_fin[0][nmu], dir_J1)   #?
-        
-                elif (integ_outer == "romberg"):
-                    I1 = ci.complex_romberg(fun_t_dir_1, (-TX_au/2), TX_au/2)
-                    dir_J1 = prefac_dir1 * I1 * gs_fin[0][nmu]           # romberg returns only the integral, so no [0] necessary
-    
-                # J_nondir,mu = sum_lambda J_nondir,mu,lambda = sum_lambda (J_res,mu,lambda + J_indir,mu,lambda)
-                J = 0
-                for nlambda in range (0,n_res_max+1):
-                    if (fin_pot_type in ('hyperbel','hypfree') and nmu > n_fin_max_list[nlambda]):  # J_nondir,mu,lambda = 0 if repulsive |fin>|mu> lies higher than |res>|lambda>
-    #                    print(nmu, nlambda, 'skipped')  #?
-                        continue
-                    E_lambda = E_lambdas[nlambda]
-                    W_au = W_lambda[nlambda]
+                for nmu in range (0, n_fin_max + 1):           # loop over all mu, calculate J_mu = J_dir,mu + J_nondir,mu
+                    E_fin_au = E_fin_au_1 + E_mus[nmu]      # E_fin_au_1: inputted electronic E_fin_au, E_mus: vibrational eigenvalues of fin state
+        #                Er_au = Er_a_au
+                    
+                    # Direct term
                     if (integ_outer == "quadrature"):
-                        res_I = ci.complex_quadrature(res_outer_fun, (-TX_au/2), TX_au/2)
-                        
-                        if not partial_GamR == 'exp':
-                            res_J1 = (prefac_res1 * res_I[0]
-                                      * gs_res[0][nlambda] * res_fin[nlambda][nmu])
-                            indir_J1 = (prefac_indir1 * res_I[0]
-                                        * indir_FCsums[nlambda] * res_fin[nlambda][nmu])
-    #                        print(nmu, nlambda, 'res_J1 =', res_J1, 'indir_J1 =', indir_J1)   #?
-                        else:
-                            res_J1 = (prefac_res1 * res_I[0]
-                                      * gs_res[0][nlambda] * res_fin_woVR[nlambda][nmu])
-                            indir_J1 = (prefac_indir1 * res_I[0]
-                                        * indir_FCsums[nlambda] * res_fin_woVR[nlambda][nmu])
-    #                        print(nmu, nlambda, 'res_J1 =', res_J1, 'indir_J1 =', indir_J1)   #?
+                        I1 = ci.complex_quadrature(fun_t_dir_1, (-TX_au/2), TX_au/2)
+                        dir_J1 = prefac_dir1 * I1[0] * gs_fin[0][nmu]        # [0] of quad integ result = integral (rest is est error & info); FC = <mu_n|kappa_0>
+    #                        print(nmu, gs_fin[0][nmu], dir_J1)   #?
         
                     elif (integ_outer == "romberg"):
-                        res_I = ci.complex_romberg(res_outer_fun, (-TX_au/2), TX_au/2)
-                        
-                        if not partial_GamR == 'exp':
-                            res_J1 = (prefac_res1 * res_I
-                                      * gs_res[0][nlambda] * res_fin[nlambda][nmu])
-                            indir_J1 = (prefac_indir1 * res_I
-                                        * indir_FCsums[nlambda] * res_fin[nlambda][nmu])
-                        else:
-                            res_J1 = (prefac_res1 * res_I
-                                      * gs_res[0][nlambda] * res_fin_woVR[nlambda][nmu])
-                            indir_J1 = (prefac_indir1 * res_I
-                                        * indir_FCsums[nlambda] * res_fin_woVR[nlambda][nmu])
+                        I1 = ci.complex_romberg(fun_t_dir_1, (-TX_au/2), TX_au/2)
+                        dir_J1 = prefac_dir1 * I1 * gs_fin[0][nmu]           # romberg returns only the integral, so no [0] necessary
     
-    
-                    J = (J
-                         + res_J1
-                         + indir_J1
-                         )
+                    # J_nondir,mu = sum_lambda J_nondir,mu,lambda = sum_lambda (J_res,mu,lambda + J_indir,mu,lambda)
+                    J = 0
+                    for nlambda in range (0,n_res_max+1):
+                        if (fin_pot_type in ('hyperbel','hypfree') and nmu > n_fin_max_list[nlambda]):  # J_nondir,mu,lambda = 0 if repulsive |fin>|mu> lies higher than |res>|lambda>
+    #                        print(nmu, nlambda, 'skipped')  #?
+                            continue
+                        E_lambda = E_lambdas[nlambda]
+                        W_au = W_lambda[nlambda]
+                        if (integ_outer == "quadrature"):
+                            res_I = ci.complex_quadrature(res_outer_fun, (-TX_au/2), TX_au/2)
+                            
+                            if not partial_GamR == 'exp':
+                                res_J1 = (prefac_res1 * res_I[0]
+                                          * gs_res[0][nlambda] * res_fin[nlambda][nmu])
+                                indir_J1 = (prefac_indir1 * res_I[0]
+                                            * indir_FCsums[nlambda] * res_fin[nlambda][nmu])
+    #                            print(nmu, nlambda, 'res_J1 =', res_J1, 'indir_J1 =', indir_J1)   #?
+                            else:
+                                res_J1 = (prefac_res1 * res_I[0]
+                                          * gs_res[0][nlambda] * res_fin_woVR[nlambda][nmu])
+                                indir_J1 = (prefac_indir1 * res_I[0]
+                                            * indir_FCsums[nlambda] * res_fin_woVR[nlambda][nmu])
+    #                            print(nmu, nlambda, 'res_J1 =', res_J1, 'indir_J1 =', indir_J1)   #?
         
-                # Total trs prob (@E_kin, t) = sum_mu |J_mu|**2
-                # For cont rep fin: int (dE_mu |J_mu|**2 E-DOS(E_mu)) = int (dR_mu |J_mu|**2 R-DOS(R_mu))
-                #   R-DOS = E-DOS * Va / R_mu**2 = E-DOS * E_mu**2 / Va. If E-DOS = 1 & R_hyp_step = const: int (dR_mu |J_mu|**2 R-DOS) ~ sum_mu (R_hyp_step |J_mu|**2 E_mu**2 / Va)
-                square = np.absolute(J + dir_J1)**2     # |J_mu|**2
-                if (fin_pot_type in ('hyperbel','hypfree')):
-                    factor = R_hyp_step * E_mus[nmu]**2 / fin_hyp_a
-                    old_square = square
-                    square = square * factor
-                sum_square = sum_square + square        # |J|**2 = sum_mu |J_mu|**2
-                #print(f'nmu = {nmu:>3}  f = {factor:.5f}  osq = {old_square:.5E}  sq = {square:.5E}  sum = {sum_square:.5E}')
-                #outfile.write(f'nmu = {nmu:>3}  f = {factor:.5f}  osq = {old_square:.5E}  sq = {square:.5E}  sum = {sum_square:.5E}\n')
+                        elif (integ_outer == "romberg"):
+                            res_I = ci.complex_romberg(res_outer_fun, (-TX_au/2), TX_au/2)
+                            
+                            if not partial_GamR == 'exp':
+                                res_J1 = (prefac_res1 * res_I
+                                          * gs_res[0][nlambda] * res_fin[nlambda][nmu])
+                                indir_J1 = (prefac_indir1 * res_I
+                                            * indir_FCsums[nlambda] * res_fin[nlambda][nmu])
+                            else:
+                                res_J1 = (prefac_res1 * res_I
+                                          * gs_res[0][nlambda] * res_fin_woVR[nlambda][nmu])
+                                indir_J1 = (prefac_indir1 * res_I
+                                            * indir_FCsums[nlambda] * res_fin_woVR[nlambda][nmu])
     
-            squares = np.append(squares, sum_square)
     
-            string = in_out.prep_output(sum_square, E_kin_au, t_au)     # returns str: E_kin_eV, t_s, sum_square = intensity
-            outlines.append(string)
+                        J = (J
+                             + res_J1
+                             + indir_J1
+                             )
+        
+                    # Total trs prob (@E_kin, t) = sum_mu |J_mu|**2
+                    # For cont rep fin: int (dE_mu |J_mu|**2 E-DOS(E_mu)) = int (dR_mu |J_mu|**2 R-DOS(R_mu))
+                    #   R-DOS = E-DOS * Va / R_mu**2 = E-DOS * E_mu**2 / Va. If E-DOS = 1 & R_hyp_step = const: int (dR_mu |J_mu|**2 R-DOS) ~ sum_mu (R_hyp_step |J_mu|**2 E_mu**2 / Va)
+                    square = np.absolute(J + dir_J1)**2     # |J_mu|**2
+                    if (fin_pot_type in ('hyperbel','hypfree')):
+                        factor = R_hyp_step * E_mus[nmu]**2 / fin_hyp_a
+                        old_square = square
+                        square = square * factor
+                    sum_square = sum_square + square        # |J|**2 = sum_mu |J_mu|**2
+                    #print(f'nmu = {nmu:>3}  f = {factor:.5f}  osq = {old_square:.5E}  sq = {square:.5E}  sum = {sum_square:.5E}')
+                    #outfile.write(f'nmu = {nmu:>3}  f = {factor:.5f}  osq = {old_square:.5E}  sq = {square:.5E}  sum = {sum_square:.5E}\n')
+    
+                squares = np.append(squares, sum_square)
+    
+                string = in_out.prep_output(sum_square, E_kin_au, t_au, E_p_au)     # returns str: E_kin_eV, E_p_eV, t_s, sum_square = intensity
+                outlines.append(string)
+
+                E_p_au = E_p_au + Ep_step_au
             
             E_kin_au = E_kin_au + E_step_au     # @ t = const.
         
@@ -1119,8 +1153,8 @@ while (t_au >= TX_au/2\
         max_pos = argrelextrema(squares, np.greater)[0]      # finds position of relative (i. e. local) maxima of |J|**2 in an array
         if (len(max_pos > 0)):                               # if there are such:
             for i in range (0, len(max_pos)):
-                print(Ekins[max_pos[i]], squares[max_pos[i]])      # print all loc max & resp E_kin
-                outfile.write(str(Ekins[max_pos[i]]) + '  ' + str(squares[max_pos[i]]) + '\n')
+                print(Ekins[max_pos[i] // len(Ep)], Ep[max_pos[i] % len(Ep)], squares[max_pos[i]])      # print all loc max & resp E_kin, E_p
+                outfile.write(str(Ekins[max_pos[i] // len(Ep)]) + '  ' + str(Ep[max_pos[i] % len(Ep)]) + '  ' + str(squares[max_pos[i]]) + '\n')
     
     # wavepacket in resonance state(s)
     wp_ampls = []

--- a/nuclear_dyn.py
+++ b/nuclear_dyn.py
@@ -184,13 +184,6 @@ if Gamma_type == 'const':
 #tau_au_2         = sciconv.second_to_atu(tau_s_2)
 #Gamma_au_2       = 1. / tau_au_2
 
-# nucl-nucl Coulomb repulsion for ICD
-if (X_ICD):
-    R_eq_au = sciconv.angstrom_to_bohr(R_eq_AA)
-    E_fin_au = E_fin_au + 1 / R_eq_au
-    print('E_fin_au = E_fin_au + 1 / R =', E_fin_au)
-    outfile.write('E_fin_au = E_fin_au + 1 / R = ' + str(E_fin_au)  + '\n')
-
 # laser parameters
 Omega_au      = sciconv.ev_to_hartree(Omega_eV)
 if (X_sinsq):

--- a/nuclear_dyn.py
+++ b/nuclear_dyn.py
@@ -1028,6 +1028,7 @@ while ((t_au <= TX_au/2) and (t_au <= tmax_au)):
             wp_string = format(nlambda, 'd') + '   ' + format(sciconv.hartree_to_ev(E_p_au), '>8.5f') + '   ' + '   ' + format(sciconv.atu_to_second(t_au), ' .18f') \
                     + '   ' + format(complex(wp_ampl), ' .15e')
             wp_ampls.append(wp_string)
+            E_p_au = E_p_au + Ep_step_au
     in_out.doout_1f(wp_res_out, wp_ampls)
 
 
@@ -1171,6 +1172,7 @@ while (t_au >= TX_au/2\
             wp_string = format(nlambda, 'd') + '   ' + format(sciconv.hartree_to_ev(E_p_au), '>8.5f') + '   ' + '   ' + format(sciconv.atu_to_second(t_au), ' .18f') \
                     + '   ' + format(complex(wp_ampl), ' .15e')
             wp_ampls.append(wp_string)
+            E_p_au = E_p_au + Ep_step_au
     in_out.doout_1f(wp_res_out, wp_ampls)
 
 

--- a/nuclear_dyn.py
+++ b/nuclear_dyn.py
@@ -828,26 +828,26 @@ res_outer_fun = lambda t1: FX_t1(t1) \
 
 # for wavepacket in resonance state
 def t_plus(t):
-    return 1/(sigma*mp.sqrt(2)) * (t - 1.j*sigma**2*(Er_au+E_lambda-1.j*mp.pi*W_au+Omega_au))
+    return 1/(sigma*mp.sqrt(2)) * (t - 1.j*sigma**2*(Er_au+E_lambda+E_p_au-1.j*mp.pi*W_au+Omega_au))
 def t_minus(t):
-    return 1/(sigma*mp.sqrt(2)) * (t - 1.j*sigma**2*(Er_au+E_lambda-1.j*mp.pi*W_au-Omega_au))
+    return 1/(sigma*mp.sqrt(2)) * (t - 1.j*sigma**2*(Er_au+E_lambda+E_p_au-1.j*mp.pi*W_au-Omega_au))
 
 def gamma_plus(T_up):
-    return ((Er_au+E_lambda-1.j*mp.pi*W_au) * (mp.erf(t_plus(T_up)) \
+    return ((Er_au+E_lambda+E_p_au-1.j*mp.pi*W_au) * (mp.erf(t_plus(T_up)) \
                                                - mp.erf(t_plus(-TX_au/2))) \
             + 1.j/sigma * mp.sqrt(2/mp.pi) * (mp.exp(-t_plus(T_up)**2) \
                                               - mp.exp(-t_plus(-TX_au/2)**2)))
 def gamma_minus(T_up):
-    return ((Er_au+E_lambda-1.j*mp.pi*W_au) * (mp.erf(t_minus(T_up)) \
+    return ((Er_au+E_lambda+E_p_au-1.j*mp.pi*W_au) * (mp.erf(t_minus(T_up)) \
                                                - mp.erf(t_minus(-TX_au/2))) \
             + 1.j/sigma * mp.sqrt(2/mp.pi) * (mp.exp(-t_minus(T_up)**2) \
                                               - mp.exp(-t_minus(-TX_au/2)**2)))
 
 def wp_res_int(t,T_up):
-    return (-A0X*0.25j * mp.exp(-1.j*t*(Er_au+E_lambda-1.j*mp.pi*W_au)) \
-            * (mp.exp(-sigma**2/2 * (Er_au+E_lambda-1.j*mp.pi*W_au+Omega_au)**2) \
+    return (-A0X*0.25j * mp.exp(-1.j*t*(Er_au+E_lambda+E_p_au-1.j*mp.pi*W_au)) \
+            * (mp.exp(-sigma**2/2 * (Er_au+E_lambda+E_p_au-1.j*mp.pi*W_au+Omega_au)**2) \
                 * gamma_plus(T_up) \
-               + mp.exp(-sigma**2/2 * (Er_au+E_lambda-1.j*mp.pi*W_au-Omega_au)**2) \
+               + mp.exp(-sigma**2/2 * (Er_au+E_lambda+E_p_au-1.j*mp.pi*W_au-Omega_au)**2) \
                 * gamma_minus(T_up)))
 
 
@@ -884,7 +884,7 @@ else:
 if (fin_pot_type in ('hyperbel','hypfree')):
     n_fin_max = n_fin_max_X
 
-# for wavepacket in resonance state(s)
+# for wavepacket in resonance state(s) (as list comprehension)
 wp_prefs = [(1.j/(n_res_max+1) * rdg_au * gs_res[0][nlambda] \
                + mp.pi/(n_res_max+1) * VEr_au * cdg_au_V * indir_FCsums[nlambda])
             for nlambda in range(n_res_max+1)]
@@ -1020,12 +1020,14 @@ while ((t_au <= TX_au/2) and (t_au <= tmax_au)):
     for nlambda in range (0,n_res_max+1):
         E_lambda = E_lambdas[nlambda]
         W_au = W_lambda[nlambda]
-        wp_I = wp_res_int(t_au,t_au)
         wp_pref = wp_prefs[nlambda] 
-        wp_ampl = wp_pref * wp_I
-        wp_string = format(nlambda, 'd') + '   ' + format(sciconv.atu_to_second(t_au), ' .18f') \
-                + '   ' + format(complex(wp_ampl), ' .15e')
-        wp_ampls.append(wp_string)
+        E_p_au = Ep_min_au
+        while (E_p_au <= Ep_max_au):
+            wp_I = wp_res_int(t_au,t_au)
+            wp_ampl = wp_pref * wp_I
+            wp_string = format(nlambda, 'd') + '   ' + format(sciconv.hartree_to_ev(E_p_au), '>8.5f') + '   ' + '   ' + format(sciconv.atu_to_second(t_au), ' .18f') \
+                    + '   ' + format(complex(wp_ampl), ' .15e')
+            wp_ampls.append(wp_string)
     in_out.doout_1f(wp_res_out, wp_ampls)
 
 
@@ -1161,12 +1163,14 @@ while (t_au >= TX_au/2\
     for nlambda in range (0,n_res_max+1):
         E_lambda = E_lambdas[nlambda]
         W_au = W_lambda[nlambda]
-        wp_I = wp_res_int(t_au,TX_au/2)
         wp_pref = wp_prefs[nlambda] 
-        wp_ampl = wp_pref * wp_I
-        wp_string = format(nlambda, 'd') + '   ' + format(sciconv.atu_to_second(t_au), ' .18f') \
-                + '   ' + format(complex(wp_ampl), ' .15e')
-        wp_ampls.append(wp_string)
+        E_p_au = Ep_min_au
+        while (E_p_au <= Ep_max_au):
+            wp_I = wp_res_int(t_au,TX_au/2)
+            wp_ampl = wp_pref * wp_I
+            wp_string = format(nlambda, 'd') + '   ' + format(sciconv.hartree_to_ev(E_p_au), '>8.5f') + '   ' + '   ' + format(sciconv.atu_to_second(t_au), ' .18f') \
+                    + '   ' + format(complex(wp_ampl), ' .15e')
+            wp_ampls.append(wp_string)
     in_out.doout_1f(wp_res_out, wp_ampls)
 
 

--- a/nuclear_dyn.py
+++ b/nuclear_dyn.py
@@ -11,7 +11,7 @@
 ##########################################################################
 # written by: Elke Fasshauer November 2020                               #
 # extended by: Alexander Riegel from July 2023 onwards                   #
-# last change: 2026-03-09 AVR                                            #
+# last change: 2026-03-27 AVR                                            #
 ##########################################################################
 
 import argparse

--- a/nuclear_dyn.py
+++ b/nuclear_dyn.py
@@ -45,6 +45,7 @@ parser = argparse.ArgumentParser(
         description='''ELDEST -- nuclear_dyn.py :
         A programme to simulate time-resolved ICD and RICD
         spectroscopy including quantum nuclear dynamics.''',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         epilog='Originally written by Elke Fasshauer, extended by Alexander V. Riegel.')
 parser.add_argument('infile', help='Input file for simulation, probably photonucl.in')
 parser.add_argument('-f', '--fc', help='''Optional file with pre-calculated "Franck-Condon overlap integrals"

--- a/nuclear_dyn.py
+++ b/nuclear_dyn.py
@@ -838,7 +838,7 @@ def gamma_minus(T_up):
                                               - mp.exp(-t_minus(-TX_au/2)**2)))
 
 def wp_res_int(t,T_up):
-    return (-A0X*0.25j * mp.exp(-1.j*t*(Er_au+E_lambda+E_p_au-1.j*mp.pi*W_au)) \
+    return (A0X*0.25j * mp.exp(-1.j*t*(Er_au+E_lambda+E_p_au-1.j*mp.pi*W_au)) \
             * (mp.exp(-sigma**2/2 * (Er_au+E_lambda+E_p_au-1.j*mp.pi*W_au+Omega_au)**2) \
                 * gamma_plus(T_up) \
                + mp.exp(-sigma**2/2 * (Er_au+E_lambda+E_p_au-1.j*mp.pi*W_au-Omega_au)**2) \

--- a/nuclear_dyn.py
+++ b/nuclear_dyn.py
@@ -192,7 +192,7 @@ elif(X_gauss):
     sigma     = np.pi * n_X / (Omega_au * np.sqrt(np.log(2)))
     FWHM      = 2 * np.sqrt( 2 * np.log(2)) * sigma
     TX_au     = 5 * sigma
-    sigma_E   = 1. / (2 * sigma)
+    sigma_E   = 1. / sigma
     width_E   = 5 * sigma_E
     EX_max_au = Omega_au + 0.5 * width_E
     print('sigma [s] = ', sciconv.atu_to_second(sigma))

--- a/nuclear_dyn.py
+++ b/nuclear_dyn.py
@@ -11,7 +11,7 @@
 ##########################################################################
 # written by: Elke Fasshauer November 2020                               #
 # extended by: Alexander Riegel from July 2023 onwards                   #
-# last change: 2026-06-02 AVR                                            #
+# last change: 2026-03-09 AVR                                            #
 ##########################################################################
 
 import argparse
@@ -43,8 +43,8 @@ if not sys.warnoptions:
 # set up argument parser
 parser = argparse.ArgumentParser(
         description='''ELDEST -- nuclear_dyn.py :
-        A programme to simulate the time-resolved RICD spectroscopy
-        including quantum nuclear dynamics.''',
+        A programme to simulate time-resolved ICD and RICD
+        spectroscopy including quantum nuclear dynamics.''',
         epilog='Originally written by Elke Fasshauer, extended by Alexander V. Riegel.')
 parser.add_argument('infile', help='Input file for simulation, probably photonucl.in')
 parser.add_argument('-f', '--fc', help='''Optional file with pre-calculated "Franck-Condon overlap integrals"

--- a/nuclear_dyn.py
+++ b/nuclear_dyn.py
@@ -1060,8 +1060,8 @@ while (t_au >= TX_au/2\
             else:
                 print('-', end = '', flush = True)
                 cnt = cnt + 1
-        E_p_au = Ep_min_au
-        while (E_p_au <= Ep_max_au):
+            E_p_au = Ep_min_au
+            while (E_p_au <= Ep_max_au):
                 #print(f'{sciconv.hartree_to_ev(E_kin_au):.2} eV')           #?
                 #outfile.write(f'{sciconv.hartree_to_ev(E_kin_au):.2} eV\n') #?
                 p_au = np.sqrt(2*E_kin_au)

--- a/nuclear_dyn.py
+++ b/nuclear_dyn.py
@@ -10,8 +10,8 @@
 #                                                                        #
 ##########################################################################
 # written by: Elke Fasshauer November 2020                               #
-# extended by: Alexander Riegel from July 2023 onwards                   #
-# last change: 2026-03-27 AVR                                            #
+# extended by: Alexander V. Riegel from July 2023 onwards                #
+# last change: 2026-06-08 AVR                                            #
 ##########################################################################
 
 import argparse
@@ -265,7 +265,7 @@ elif Gamma_type == 'R6':
         VEr_au_woVR = VEr_au
         print('VEr_au = ', VEr_au)
         outfile.write('VEr_au = ' + str(VEr_au) + '\n')
-    VEr_au = VEr_au*res_Req**3                            # adjusts VEr_au by the R dependent factor
+    VEr_au = VEr_au*gs_Req**3                            # adjusts VEr_au by the R dependent factor
     print('VEr_au_adjusted = ', VEr_au)
     outfile.write('VEr_au_adjusted = ' + str(VEr_au) + '\n')
 elif Gamma_type == 'external':

--- a/photonucl.in
+++ b/photonucl.in
@@ -1,3 +1,5 @@
+# process
+prc           = ICD              # options: ICD/RICD
 # transitions dipole moments
 rdg_au        = 0.70             # transition dipole moment into the resonance state
 cdg_au        = 0.5              # transition dipole moment into any continuum state
@@ -37,6 +39,10 @@ timestep_s    = 149.9E-15        # evaluate expression every timestep_s seconds
 E_min_eV      =  9.7995
 E_max_eV      = 10.5
 E_step_eV     =  0.001           # energy difference between different evaluated electron kinetic energies
+#
+Ep_min_eV     = 2.0              # Ep_min and _max are set to zero for prc = RICD
+Ep_max_eV     = 8.0
+Ep_step_eV    = 0.005            # energy difference between different evaluated photoelectron kinetic energies
 #
 integ         = analytic         # options: analytic, (quadrature, romberg - both currently unavailable)
 integ_outer   = quadrature       # options: quadrature, romberg

--- a/res_wavepacket.py
+++ b/res_wavepacket.py
@@ -64,8 +64,16 @@ else:
     sys.exit('Input file for simulation and potential settings "%s" does not exist.' % settings)
 
 with open(os.devnull, 'w') as dummyfile, silence_print():
-    (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
-     _, _, _, _, _, _, _, _, _, _, _, _, mass1, mass2, _, _, _, _, _, _, De, alpha, Req, _, _, _, _, _, _
+    (X_ICD, X_RICD, _, _,
+     _, _, _, _, _, _, _, _, _,
+     _, _, _, _, _, _,
+     _, _, _, _, _, _, _, _, _,
+     _, _, _, Ep_step_eV, _, _, Ep_min_eV, Ep_max_eV,
+     _, _, _, _, _, _, _,
+     mass1, mass2, _, _,
+     _, _, _, _,
+     De, alpha, Req, _,
+     _, _, _, _, _
      ) = in_out.read_input(settings, dummyfile)
 
 outfile=f'wf_{infile}'
@@ -82,12 +90,24 @@ R_arr = np.linspace(R_low, R_high, R_len)
 
 t_low, t_high = [float(num) for num in args.time_lims]
 
+# choose E_p value
+if X_ICD:   # Use centre E_p value
+    num_p = int(((Ep_max_eV-Ep_min_eV)//Ep_step_eV)/2)
+elif X_RICD:
+    num_p = int(0)
 
 
 ##########
 
 with open(infile,'r') as f:
-    data = pd.read_csv(f, header=None, sep='   ', engine='python')
+    raw_data = pd.read_csv(f, header=None, sep=r'\s+', engine='python')
+
+# Select only rows with chosen E_p value, then drop E_p column and renumber columns
+Ep_eV = raw_data[1].iloc[num_p]
+print(f'num_p = {num_p} <=> E_p = {Ep_eV:>8.5f} eV')
+data = raw_data.loc[raw_data[1] == Ep_eV].reset_index(drop=True)
+data.drop(1,axis=1,inplace=True)
+data.columns = range(data.columns.size)
 
 # Morse potential
 red_mass = wf.red_mass_au(mass1,mass2)

--- a/res_wavepacket.py
+++ b/res_wavepacket.py
@@ -37,6 +37,7 @@ parser = argparse.ArgumentParser(
         description='''This script calculates the wavepacket in the resonance state
         from the projections onto the vibronic resonance states
         that are the output of res_nuclear_dyn.py (in wp_res.dat).''',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         epilog='Alexander V. Riegel, 2024.')
 parser.add_argument('-w', '--wavepacket_infile', default='wp_res.dat',
                     help='File which contains the projections of the wavefunction on the vibronic resonance states.')

--- a/res_wavepacket.py
+++ b/res_wavepacket.py
@@ -158,7 +158,7 @@ popfile=f'pop_{infile}'
 pop = pd.DataFrame() 
 for t in range(len(eata)//len(R_arr)):
     pop.loc[t, 0] = mata[1][t]
-    pop.loc[t, 1] = simpson(eata[t*len(R_arr):(t+1)*len(R_arr)][:,3]**2,dx=R_arr[1]-R_arr[0])
+    pop.loc[t, 1] = simpson(eata[t*len(R_arr):(t+1)*len(R_arr)][:,3],dx=R_arr[1]-R_arr[0])
 np.savetxt(popfile, pop, delimiter='   ', fmt=['% .7e', '% .15e'])
 
 if args.lambda_indiv:
@@ -168,7 +168,7 @@ if args.lambda_indiv:
         pop_sub = pd.DataFrame() 
         for t in range(len(eata_sub)//len(R_arr)):
             pop_sub.loc[t, 0] = mata[1][t]
-            pop_sub.loc[t, 1] = simpson(eata_sub[t*len(R_arr):(t+1)*len(R_arr)][:,3]**2,dx=R_arr[1]-R_arr[0])
+            pop_sub.loc[t, 1] = simpson(eata_sub[t*len(R_arr):(t+1)*len(R_arr)][:,3],dx=R_arr[1]-R_arr[0])
         np.savetxt(popfile_sub, pop_sub, delimiter='   ', fmt=['% .7e', '% .15e'])
 
 
@@ -178,7 +178,7 @@ expect = pd.DataFrame()
 #expect.loc[0, 1] = 0.
 for t in range(1,len(eata)//len(R_arr)):
     expect.loc[t-1, 0] = mata[1][t]
-    expect.loc[t-1, 1] = simpson(eata[t*len(R_arr):(t+1)*len(R_arr)][:,0]*eata[t*len(R_arr):(t+1)*len(R_arr)][:,3]**2,dx=R_arr[1]-R_arr[0])/pop[1][t]
+    expect.loc[t-1, 1] = simpson(eata[t*len(R_arr):(t+1)*len(R_arr)][:,0]*eata[t*len(R_arr):(t+1)*len(R_arr)][:,3],dx=R_arr[1]-R_arr[0])/pop[1][t]
 np.savetxt(expectfile, expect, delimiter='   ', fmt=['% .7e', '% .15e'])
 
 

--- a/res_wavepacket.py
+++ b/res_wavepacket.py
@@ -47,6 +47,8 @@ parser.add_argument('-r', '--r_lims', nargs=3, default=[5.8, 6.8, 7], metavar=('
                     help='Lower and upper limit for R (in a.u.) as well as exponent for number of points with num = 2**R_num_exp + 1.')
 parser.add_argument('-t', '--time_lims', nargs=2, default=[-1.2, 100.], metavar=('t_low', 't_up'),
                     help='Iterable with lower and upper limit for time t (in fs).')
+parser.add_argument('-l', '--lambda_indiv', default=False,
+                    help='Calculate "populations" also for individual vibrational resonance levels.')
 args = parser.parse_args()
 
 
@@ -147,7 +149,8 @@ np.savetxt(outfile, oata, delimiter='   ', fmt=['%10.7f', '% .7e', '% i', '% .15
 
 # Extract the total resonance-state wavepacket, restructure the file for pm3d and calc population & R expectation value
 outfile_pm3d=f'pm3d_{outfile}'
-eata = oata[-len(sata[0])//N_lambda:]
+step_width = len(sata[0])//N_lambda
+eata = oata[-step_width:]
 np.savetxt(outfile_pm3d, eata, delimiter='   ', fmt=['%10.7f', '% .7e', '% i', '% .15e'])
 subprocess.call(['sed', '-i', f'/{R_high:10.7f}/G', outfile_pm3d])
 
@@ -157,6 +160,17 @@ for t in range(len(eata)//len(R_arr)):
     pop.loc[t, 0] = mata[1][t]
     pop.loc[t, 1] = simpson(eata[t*len(R_arr):(t+1)*len(R_arr)][:,3]**2,dx=R_arr[1]-R_arr[0])
 np.savetxt(popfile, pop, delimiter='   ', fmt=['% .7e', '% .15e'])
+
+if lambda_indiv:
+    for n in range(N_lambda):
+        eata_sub = oata[n*step_width:(n+1)*step_width]
+        popfile_sub=f'pop_{n}_{infile}'
+        pop_sub = pd.DataFrame() 
+        for t in range(len(eata_sub)//len(R_arr)):
+            pop_sub.loc[t, 0] = mata[1][t]
+            pop_sub.loc[t, 1] = simpson(eata_sub[t*len(R_arr):(t+1)*len(R_arr)][:,3]**2,dx=R_arr[1]-R_arr[0])
+        np.savetxt(popfile_sub, pop_sub, delimiter='   ', fmt=['% .7e', '% .15e'])
+
 
 expectfile=f'expect-R_{infile}'
 expect = pd.DataFrame()

--- a/res_wavepacket.py
+++ b/res_wavepacket.py
@@ -152,7 +152,7 @@ outfile_pm3d=f'pm3d_{outfile}'
 step_width = len(sata[0])//N_lambda
 eata = oata[-step_width:]
 np.savetxt(outfile_pm3d, eata, delimiter='   ', fmt=['%10.7f', '% .7e', '% i', '% .15e'])
-subprocess.call(['sed', '-i', f'/{R_high:10.7f}/G', outfile_pm3d])
+subprocess.call(['sed', '-i', f'/^[[:space:]]*{f"{R_high:.7f}"}/G', outfile_pm3d])
 
 popfile=f'pop_{infile}'
 pop = pd.DataFrame() 
@@ -161,7 +161,7 @@ for t in range(len(eata)//len(R_arr)):
     pop.loc[t, 1] = simpson(eata[t*len(R_arr):(t+1)*len(R_arr)][:,3]**2,dx=R_arr[1]-R_arr[0])
 np.savetxt(popfile, pop, delimiter='   ', fmt=['% .7e', '% .15e'])
 
-if lambda_indiv:
+if args.lambda_indiv:
     for n in range(N_lambda):
         eata_sub = oata[n*step_width:(n+1)*step_width]
         popfile_sub=f'pop_{n}_{infile}'


### PR DESCRIPTION
A copy of eldest.out from a previous calculation can be read in as FC input without having to alter the file. (Only if an additional FC input file without Gamma(R) dependence for partialGamma mode is to be used, it may have to be slightly modified so that there is only one res-fin block. If the additional file was produced by an additional calculation in which Gamma(R) was set constant all the way, there will only be one res-fin block anyway and no further changes will be necessary.) 